### PR TITLE
Avoiding trivial getters.

### DIFF
--- a/src/main/java/com/inaka/galgo/GalgoOptions.java
+++ b/src/main/java/com/inaka/galgo/GalgoOptions.java
@@ -21,10 +21,10 @@ import java.io.Serializable;
 
 public final class GalgoOptions implements Serializable {
 
-    private final int numberOfLines;
-    private final int backgroundColor;
-    private final int textColor;
-    private final int textSize;
+    public final int numberOfLines;
+    public final int backgroundColor;
+    public final int textColor;
+    public final int textSize;
 
     /**
      * Contains options for Galgo. Defines
@@ -35,22 +35,6 @@ public final class GalgoOptions implements Serializable {
         backgroundColor = builder.backgroundColor;
         textColor = builder.textColor;
         textSize = builder.textSize;
-    }
-
-    public int getNumberOfLines() {
-        return numberOfLines;
-    }
-
-    public int getBackgroundColor() {
-        return backgroundColor;
-    }
-
-    public int getTextColor() {
-        return textColor;
-    }
-
-    public int getTextSize() {
-        return textSize;
     }
 
     /**

--- a/src/main/java/com/inaka/galgo/GalgoService.java
+++ b/src/main/java/com/inaka/galgo/GalgoService.java
@@ -63,17 +63,17 @@ public class GalgoService extends Service {
     public void displayText(String text) {
 
         Spannable spannable = new SpannableString(text);
-        spannable.setSpan(new BackgroundColorSpan(mOptions.getBackgroundColor()),0, text.length(),
+        spannable.setSpan(new BackgroundColorSpan(mOptions.backgroundColor),0, text.length(),
                 Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
 
-        if(mTextView.getLineCount() > mOptions.getNumberOfLines()) {
+        if(mTextView.getLineCount() > mOptions.numberOfLines) {
             mTextView.setText(spannable);
         } else {
             mTextView.append(spannable);
         }
 
-        mTextView.setTextSize(mOptions.getTextSize());
-        mTextView.setTextColor(mOptions.getTextColor());
+        mTextView.setTextSize(mOptions.textSize);
+        mTextView.setTextColor(mOptions.textColor);
         mTextView.append("\n");
     }
 


### PR DESCRIPTION
Since instance fields in `GalgoOptions`are final and its getter methods have no additional functionality, they are [unnecessary](http://developer.android.com/training/articles/perf-tips.html#GettersSetters).
