### PR TITLE
Added android-maven plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,15 @@
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.github.dcendents:android-maven-plugin:1.2'
+    }
+}
+
 apply plugin: 'com.android.library'
+apply plugin: 'android-maven'
 
 android {
     compileSdkVersion 21


### PR DESCRIPTION
With android-maven plugin galgo can now be installed in the local maven repository:

    gradle install

In addition its now possible to get it as a maven dependency: 
https://jitpack.io/#jitpack/galgo/1.0.2 : )

after a new release