### PR TITLE
Allow Android M+ (and config updates)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,25 +1,24 @@
+apply plugin: 'com.android.library'
 buildscript {
     repositories {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.2'
+        classpath 'com.android.tools.build:gradle:2.2.0'
         classpath 'com.github.dcendents:android-maven-plugin:1.2'
     }
 }
 
-apply plugin: 'com.android.library'
-apply plugin: 'android-maven'
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 26
+    buildToolsVersion '26.0.1'
 
     defaultConfig {
         minSdkVersion 9
-        targetSdkVersion 21
+        targetSdkVersion 26
         versionCode 2
-        versionName "1.0.2"
+        versionName "1.0.3"
     }
     buildTypes {
         release {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Thu Aug 03 11:59:08 BST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip

--- a/src/main/java/com/inaka/galgo/Galgo.java
+++ b/src/main/java/com/inaka/galgo/Galgo.java
@@ -22,10 +22,12 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.ServiceConnection;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Handler;
 import android.os.IBinder;
 import android.os.Looper;
 import android.os.Message;
+import android.provider.Settings;
 import android.util.Log;
 
 public class Galgo {
@@ -48,6 +50,7 @@ public class Galgo {
 
     /**
      * * Starts a new Galgo with custom {@link com.inaka.galgo.GalgoOptions}
+     *
      * @param context Context
      * @param options Custom {@link com.inaka.galgo.GalgoOptions}
      */
@@ -59,6 +62,7 @@ public class Galgo {
 
     /**
      * Starts a new Galgo with default {@link com.inaka.galgo.GalgoOptions}
+     *
      * @param context Context
      */
     public static void enable(Context context) {
@@ -105,10 +109,17 @@ public class Galgo {
 
     private static void checkPermission(Context context) {
         String permission = "android.permission.SYSTEM_ALERT_WINDOW";
-        int status = context.checkCallingOrSelfPermission(permission);
-        if (status == PackageManager.PERMISSION_DENIED) {
-            throw new IllegalStateException("in order to use Galgo, " +
-                    "please add the permission " + permission + " to your AndroidManifest.xml");
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            if (!Settings.canDrawOverlays(context)) {
+                throw new IllegalStateException("in order to use Galgo, " +
+                        "please add the permission " + permission + " to your AndroidManifest.xml");
+            }
+        } else {
+            int status = context.checkCallingOrSelfPermission(permission);
+            if (status == PackageManager.PERMISSION_DENIED) {
+                throw new IllegalStateException("in order to use Galgo, " +
+                        "please add the permission " + permission + " to your AndroidManifest.xml");
+            }
         }
     }
 }


### PR DESCRIPTION
A very simple change to Galgo#checkPermissions to use android.provider.Settings#canDrawOverlays() for M+ support

Updated gradlew to 2.2.0
Updated Build tools to 26.0.1
Updated targetVersion to 26

Tested on 7.1.2, 6.0.1, 5.1.1, 4.4.4

